### PR TITLE
Sync the GitHub runner clock with the Windows time server (#99)

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -23,7 +23,11 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
-        
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
+      
       # Create or update identifiers for app
       - name: Fastlane Provision
         run: fastlane identifiers

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
       
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
+      
       # Build signed Loop IPA file
       - name: Fastlane Build & Archive
         run: fastlane build_loop

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -23,7 +23,11 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
-        
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
+      
       # Create or update certificates for app
       - name: Create Certificates
         run: fastlane certs

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -10,6 +10,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
       
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
+      
       # Validates the repo secrets
       - name: Validate Secrets
         run: |


### PR DESCRIPTION
Adding a step to workflow jobs that interface Apple servers, as a workaround for build issues caused by runner clocks being out of sync. See https://github.com/actions/runner issue number 2996 for details.

name: Sync clock
run: sudo sntp -sS time.windows.com
Added to the following workflows / jobs:

validate_secrets.yml / validate-fastlane-secrets
add_identifiers.yml / identifiers
build_loop.yml / build
create_certs.yml / certificates